### PR TITLE
[RPS-23] Allow all boxes to use `aws_bootstrap`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 /.mk
 /.vagrant
 /.venv
+/manifest.json
 /output-virtualbox-iso
 /vagrant/config_override.yml
 /vendor

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ PWD = $(shell pwd)
 REGION ?= eu-west-1
 ROLE ?=
 USERNAME ?=
-VENV ?= .venv
+VENV ?= $(PWD)/.venv
 
 # Ansible 2.2.1 introduced a bug with paths for "local" connections
 export HOME
@@ -122,6 +122,7 @@ ami: .artefacts .log vendor/packer vendor/jq $(VENV) ansible/roles/vendor
 		-var 'role=$(ROLE)' \
 		-var 'root_dir=$(PWD)/ansible' \
 		"packer/ami.json"
+	rm -rf self.tgz
 
 ## Debug AMI build process
 # Usage: make ami_debug ROLE=api_storelocator USERNAME=iam.key.name
@@ -203,6 +204,19 @@ box: .artefacts/ubuntu-16.04.3-server-amd64.iso $(VENV) vendor/packer ansible/ro
 		-var 'role=$(ROLE)' \
 		-var 'root_dir=$(PWD)/ansible' \
 		"packer/vagrant.json"
+
+## Configure localhost
+# ! DO NOT RUN LOCALLY !
+# This target is designed to be used for bootstraping machine in given environment.
+# Usage:
+#   make ansible_configure_local ROLE=bastion
+ansible_configure_local:
+	cd ansible && ansible-playbook \
+		-i inventories/localhost \
+		-e role=$(ROLE) \
+		-e root_dir=/bootstrap/ansible \
+		--tags=configure \
+		playbooks/bootstrap.yml
 
 ## Delete all downloaded and generated files
 clean:

--- a/ansible/inventories/localhost
+++ b/ansible/inventories/localhost
@@ -1,5 +1,5 @@
 #!/bin/bash
-ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../.."
 echo "{
   \"localhost\": {
     \"ansible_connection\": \"local\",

--- a/ansible/playbooks/ami.yml
+++ b/ansible/playbooks/ami.yml
@@ -1,3 +1,20 @@
 ---
 
 - include: "{{ root_dir }}/roles/service/{{ role }}/playbook.yml"
+
+- name: Ensure common roles
+  hosts: "{{ hosts }}"
+
+  pre_tasks:
+    - name: Delete current bootstrap folder
+      become: yes
+      file:
+        path: /bootstrap
+        state: absent
+      tags:
+        - build
+
+  roles:
+    - role: ansible-city.aws_bootstrap
+      aws_bootstrap:
+        teleport_mode: standard

--- a/ansible/playbooks/bootstrap.yml
+++ b/ansible/playbooks/bootstrap.yml
@@ -1,0 +1,8 @@
+---
+# bootstrap
+
+- name: Bootstrap
+  hosts: localhost
+
+  roles:
+    - role: "{{ role }}"

--- a/ansible/roles/service/base_image/defaults/main.yml
+++ b/ansible/roles/service/base_image/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 
 base_image:
+  sysstat_enabled: "false"
   groups: [ ]
   users: [ ]

--- a/ansible/roles/service/base_image/handlers/main.yml
+++ b/ansible/roles/service/base_image/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+
+- name: restart sysstat
+  become: yes
+  service:
+    name: sysstat
+    state: restarted

--- a/ansible/roles/service/base_image/tasks/build.yml
+++ b/ansible/roles/service/base_image/tasks/build.yml
@@ -1,0 +1,61 @@
+---
+
+- name: Install base utilities
+  become: yes
+  apt:
+    name: "{{ item }}"
+  with_items:
+    - curl
+    - dnsutils
+    - htop
+    - iftop
+    - iotop
+    - screen
+    - sysstat
+    - tcptraceroute
+    - traceroute
+    - vim
+    - wget
+
+- name: Setup sysstat config
+  become: yes
+  template:
+    src: sysstat.j2
+    dest: /etc/default/sysstat
+  notify:
+    - restart sysstat
+
+- name: Disable unattended updates
+  become: yes
+  lineinfile:
+    dest: /etc/apt/apt.conf.d/10periodic
+    line: "APT::Periodic::Unattended-Upgrade \"0\";"
+    regexp: ^APT::Periodic::Unattended-Upgrade
+
+- name: Clean apt
+  become: yes
+  apt:
+    autoremove: yes
+    cache_valid_time: 0
+    update_cache: yes
+
+- name: Disable daily updates
+  become: yes
+  command: "{{ item }}"
+  with_items:
+    - systemctl disable apt-daily.service # disable run when system boot
+    - systemctl disable apt-daily.timer   # disable timer run
+  tags:
+    - skip_ansible_lint
+
+- name: Ensure ssh timeout
+  become: yes
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+  with_items:
+    - regexp: ^ClientAliveInterval
+      line: ClientAliveInterval 900
+    - regexp: ^ClientAliveCountMax
+      line: ClientAliveCountMax 0

--- a/ansible/roles/service/base_image/tasks/main.yml
+++ b/ansible/roles/service/base_image/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Include build tasks
+  include: build.yml
+  tags:
+    - build

--- a/ansible/roles/service/base_image/templates/sysstat.j2
+++ b/ansible/roles/service/base_image/templates/sysstat.j2
@@ -1,0 +1,1 @@
+ENABLED="{{ base_image.sysstat_enabled }}"

--- a/ansible/roles/service/bastion/defaults/main.yml
+++ b/ansible/roles/service/bastion/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+
+bastion:
+  aws:
+    hosted_zone_id: ~
+    internal_hosted_zone_id: ~

--- a/ansible/roles/service/bastion/playbook.yml
+++ b/ansible/roles/service/bastion/playbook.yml
@@ -1,0 +1,15 @@
+
+- name: Base Image
+  hosts: "{{ hosts }}"
+
+  pre_tasks:
+    - name: Update apt
+      become: yes
+      apt:
+        cache_valid_time: 1800
+        update_cache: yes
+      tags:
+        - build
+
+  roles:
+    - role: bastion

--- a/ansible/roles/service/bastion/tasks/main.yml
+++ b/ansible/roles/service/bastion/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+
+- include: configure.yml
+  tags:
+    - configure

--- a/ansible/roles/vendor.yml
+++ b/ansible/roles/vendor.yml
@@ -1,5 +1,8 @@
 ---
 
+- role: ansible-city.aws_bootstrap
+  version: v1.0
+
 - role: sansible.java
   version: v1.0
 


### PR DESCRIPTION
The `aws_bootstrap` role is now applied to all AMIs. There is also new
make target `ansible_configure_local` to configure machine once it is
started in AWS environment.